### PR TITLE
[Fix] 엔티티 컬럼명 오타 수정 및 잘못된 참조 수정

### DIFF
--- a/src/main/java/com/icando/paragraphCompletion/entity/ParagraphCompletion.java
+++ b/src/main/java/com/icando/paragraphCompletion/entity/ParagraphCompletion.java
@@ -15,10 +15,10 @@ public class ParagraphCompletion extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "paragrahp_completion_id")
+    @Column(name = "paragraph_completion_id")
     private Long id;
 
-    @Column(name = "paragrahp_completion_content")
+    @Column(name = "paragraph_completion_content")
     private String content;
 
     @ManyToOne (fetch = FetchType.LAZY)

--- a/src/main/java/com/icando/paragraphCompletion/entity/ParagraphWord.java
+++ b/src/main/java/com/icando/paragraphCompletion/entity/ParagraphWord.java
@@ -13,7 +13,7 @@ public class ParagraphWord {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "paragrahp_word_id")
+    @Column(name = "paragraph_word_id")
     private Long id;
 
     @Column

--- a/src/main/java/com/icando/paragraphCompletion/entity/ParagraphWord.java
+++ b/src/main/java/com/icando/paragraphCompletion/entity/ParagraphWord.java
@@ -1,6 +1,5 @@
 package com.icando.paragraphCompletion.entity;
 
-import com.icando.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/icando/randomBox/entity/RandomBoxHistory.java
+++ b/src/main/java/com/icando/randomBox/entity/RandomBoxHistory.java
@@ -22,6 +22,6 @@ public class RandomBoxHistory extends BaseEntity {
     private Member member;
 
     @ManyToOne (fetch = FetchType.LAZY)
-    @JoinColumn(name ="random_box_history_id")
-    private RandomBoxHistory randomBoxHistory;
+    @JoinColumn(name ="random_box_id")
+    private RandomBox randomBox;
 }


### PR DESCRIPTION
## 📌 PR 제목
[Fix] 엔티티 컬럼명 오타 수정 및 잘못된 참조 수정


## 📌 개요

ParagraphCompletion 도메인의 컬럼명 오타 수정 및 RandomBoxHistory 엔터티의 잘못된 참조 수정

## 🛠️ 작업 내용
- [x] 변경 사항 요약
- [x] 주요 변경 사항 설명
- [x] 관련 이슈 번호 (`#이슈번호`)
### ParagraphCompletion 도메인 칼럼명 수정

- 오타 'paragrahp'를 'paragraph'로 수정했습니다.

### RandomBoxHistory 필드 수정

- RandomBoxHistory가 RandomBoxHistory를 재참조 하고 있는 것을 RandomBox를 참조하도록 수정했습니다.


## 📌 테스트 케이스
- [ ] 기능 정상 동작 확인
- [ ] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [ ] 코드 스타일 및 컨벤션 준수 확인
- [ ] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등

## 관련 이슈
#24 