### PR TITLE
[Feature] 문단완성 글 조회 기능 구현

### DIFF
--- a/src/main/java/com/icando/member/entity/Mbti.java
+++ b/src/main/java/com/icando/member/entity/Mbti.java
@@ -13,7 +13,7 @@ public class Mbti extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "post_id")
+    @Column(name = "mbti_id")
     private Long id;
 
     @Column(name = "mbti_name")

--- a/src/main/java/com/icando/paragraphCompletion/controller/ParagraphCompletionController.java
+++ b/src/main/java/com/icando/paragraphCompletion/controller/ParagraphCompletionController.java
@@ -1,6 +1,8 @@
 package com.icando.paragraphCompletion.controller;
 
 import com.icando.global.success.SuccessResponse;
+import com.icando.paragraphCompletion.dto.ParagraphCompletionRequest;
+import com.icando.paragraphCompletion.dto.ParagraphCompletionResponse;
 import com.icando.paragraphCompletion.enums.ParagraphCompletionSuccessCode;
 import com.icando.paragraphCompletion.service.ParagraphCompletionService;
 import jakarta.validation.Valid;
@@ -8,10 +10,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -27,6 +26,18 @@ public class ParagraphCompletionController {
                 SuccessResponse.of(
                         ParagraphCompletionSuccessCode.RANDOM_WORD_SUCCESS,
                         paragraphCompletionService.generateWords(count)
+                )
+        );
+    }
+
+    @PostMapping()
+    public ResponseEntity<SuccessResponse<ParagraphCompletionResponse>> writeParagraphCompletionArticle(@Valid @RequestBody ParagraphCompletionRequest paragraphCompletionRequest) {
+        //TODO: 현재는 1으로 고정, 추후에 UserDetails에서 MemberId를 가져와야 함
+        ParagraphCompletionResponse response = paragraphCompletionService.insertParagraphCompletionArticle(1L, paragraphCompletionRequest);
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ParagraphCompletionSuccessCode.PARAGRAPH_COMPLETION_CREATE_SUCCESS,
+                        response
                 )
         );
     }

--- a/src/main/java/com/icando/paragraphCompletion/controller/ParagraphCompletionController.java
+++ b/src/main/java/com/icando/paragraphCompletion/controller/ParagraphCompletionController.java
@@ -41,4 +41,16 @@ public class ParagraphCompletionController {
                 )
         );
     }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<SuccessResponse<ParagraphCompletionResponse>> getParagraphCompletionArticle(@PathVariable Long id) {
+        //TODO: 현재는 1으로 고정, 추후에 UserDetails에서 MemberId를 가져와야 함
+        ParagraphCompletionResponse response = paragraphCompletionService.getParagraphCompletionArticle(1L, id);
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        ParagraphCompletionSuccessCode.PARAGRAPH_COMPLETION_READ_SUCCESS,
+                        response
+                )
+        );
+    }
 }

--- a/src/main/java/com/icando/paragraphCompletion/dto/ParagraphCompletionRequest.java
+++ b/src/main/java/com/icando/paragraphCompletion/dto/ParagraphCompletionRequest.java
@@ -1,0 +1,23 @@
+package com.icando.paragraphCompletion.dto;
+
+import com.icando.member.entity.Member;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class ParagraphCompletionRequest {
+    @NotBlank
+    @Size(min = 100, max = 600, message = "글은 100자 이상 600자 이하로 작성해주세요.")
+    private String content;
+
+    @NotEmpty
+    private List<String> words;
+}

--- a/src/main/java/com/icando/paragraphCompletion/dto/ParagraphCompletionResponse.java
+++ b/src/main/java/com/icando/paragraphCompletion/dto/ParagraphCompletionResponse.java
@@ -1,0 +1,31 @@
+package com.icando.paragraphCompletion.dto;
+
+import com.icando.member.entity.Member;
+import com.icando.paragraphCompletion.entity.ParagraphCompletion;
+import com.icando.paragraphCompletion.entity.ParagraphWord;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class ParagraphCompletionResponse {
+    private Long id;
+
+    private String content;
+
+    private List<String> words;
+
+    // TODO: Feedback DTO 추가해야함
+
+    public static ParagraphCompletionResponse of(ParagraphCompletion paragraphCompletion) {
+        ParagraphCompletionResponse response = new ParagraphCompletionResponse();
+        response.id = paragraphCompletion.getId();
+        response.content = paragraphCompletion.getContent();
+        response.words = paragraphCompletion.getParagraphWords().stream().map(ParagraphWord::getWord).toList();
+        return response;
+    }
+}

--- a/src/main/java/com/icando/paragraphCompletion/entity/ParagraphCompletion.java
+++ b/src/main/java/com/icando/paragraphCompletion/entity/ParagraphCompletion.java
@@ -3,10 +3,16 @@ package com.icando.paragraphCompletion.entity;
 import com.icando.feedback.entity.Feedback;
 import com.icando.global.BaseEntity;
 import com.icando.member.entity.Member;
+import com.icando.paragraphCompletion.dto.ParagraphCompletionRequest;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -25,8 +31,17 @@ public class ParagraphCompletion extends BaseEntity {
     @JoinColumn(name ="member_id" , nullable = false)
     private Member member;
 
-    @OneToOne (fetch = FetchType.LAZY)
-    @JoinColumn(name ="feedback_id" , nullable = false)
+    @OneToOne (fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name ="feedback_id")
     private Feedback feedback;
 
+    @OneToMany(mappedBy = "paragraphCompletion", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ParagraphWord> paragraphWords = new ArrayList<>();
+
+    public static ParagraphCompletion of(@NotBlank @Size(max = 600, message = "글은 600자 이하로 작성해주세요.") String content, Member member) {
+        ParagraphCompletion paragraphCompletion = new ParagraphCompletion();
+        paragraphCompletion.content = content;
+        paragraphCompletion.member = member;
+        return paragraphCompletion;
+    }
 }

--- a/src/main/java/com/icando/paragraphCompletion/entity/ParagraphWord.java
+++ b/src/main/java/com/icando/paragraphCompletion/entity/ParagraphWord.java
@@ -21,4 +21,11 @@ public class ParagraphWord {
     @ManyToOne (fetch = FetchType.LAZY)
     @JoinColumn(name ="paragraph_completion_id" , nullable = false)
     private ParagraphCompletion paragraphCompletion;
+
+    public static ParagraphWord of(String word, ParagraphCompletion paragraphCompletion) {
+        ParagraphWord paragraphWord = new ParagraphWord();
+        paragraphWord.word = word;
+        paragraphWord.paragraphCompletion = paragraphCompletion;
+        return paragraphWord;
+    }
 }

--- a/src/main/java/com/icando/paragraphCompletion/enums/ParagraphCompletionSuccessCode.java
+++ b/src/main/java/com/icando/paragraphCompletion/enums/ParagraphCompletionSuccessCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum ParagraphCompletionSuccessCode implements SuccessCode {
-    RANDOM_WORD_SUCCESS(HttpStatus.OK, "랜덤 단어 조회 성공");
+    RANDOM_WORD_SUCCESS(HttpStatus.OK, "랜덤 단어 조회 성공"),
+    PARAGRAPH_COMPLETION_CREATE_SUCCESS(HttpStatus.CREATED, "문단 완성 글 작성 성공");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/icando/paragraphCompletion/enums/ParagraphCompletionSuccessCode.java
+++ b/src/main/java/com/icando/paragraphCompletion/enums/ParagraphCompletionSuccessCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ParagraphCompletionSuccessCode implements SuccessCode {
     RANDOM_WORD_SUCCESS(HttpStatus.OK, "랜덤 단어 조회 성공"),
-    PARAGRAPH_COMPLETION_CREATE_SUCCESS(HttpStatus.CREATED, "문단 완성 글 작성 성공");
+    PARAGRAPH_COMPLETION_CREATE_SUCCESS(HttpStatus.CREATED, "문단 완성 글 작성 성공"),
+    PARAGRAPH_COMPLETION_READ_SUCCESS(HttpStatus.OK, "문단 완성 글 조회 성공");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/icando/paragraphCompletion/exception/ParagraphCompletionErrorCode.java
+++ b/src/main/java/com/icando/paragraphCompletion/exception/ParagraphCompletionErrorCode.java
@@ -1,0 +1,28 @@
+package com.icando.paragraphCompletion.exception;
+
+import com.icando.global.error.core.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+public enum ParagraphCompletionErrorCode implements ErrorCode {
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    WORD_NOT_IN_CONTENT(HttpStatus.BAD_REQUEST, "내용에 포함되어 있지 않은 단어가 있습니다."),
+    INVALID_WORD_COUNT(HttpStatus.BAD_REQUEST, "단어 목록이 비어있습니다."),
+    INVALID_CONTENT(HttpStatus.BAD_REQUEST, "내용이 비어있습니다."),;
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/src/main/java/com/icando/paragraphCompletion/exception/ParagraphCompletionErrorCode.java
+++ b/src/main/java/com/icando/paragraphCompletion/exception/ParagraphCompletionErrorCode.java
@@ -10,7 +10,8 @@ public enum ParagraphCompletionErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     WORD_NOT_IN_CONTENT(HttpStatus.BAD_REQUEST, "내용에 포함되어 있지 않은 단어가 있습니다."),
     INVALID_WORD_COUNT(HttpStatus.BAD_REQUEST, "단어 목록이 비어있습니다."),
-    INVALID_CONTENT(HttpStatus.BAD_REQUEST, "내용이 비어있습니다."),;
+    INVALID_CONTENT(HttpStatus.BAD_REQUEST, "내용이 비어있습니다."),
+    PARAGRAPH_COMPLETION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 문단완성 글이 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/icando/paragraphCompletion/exception/ParagraphCompletionErrorCode.java
+++ b/src/main/java/com/icando/paragraphCompletion/exception/ParagraphCompletionErrorCode.java
@@ -2,10 +2,9 @@ package com.icando.paragraphCompletion.exception;
 
 import com.icando.global.error.core.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
-@RequiredArgsConstructor(onConstructor_ = @Autowired)
+@RequiredArgsConstructor
 public enum ParagraphCompletionErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     WORD_NOT_IN_CONTENT(HttpStatus.BAD_REQUEST, "내용에 포함되어 있지 않은 단어가 있습니다."),

--- a/src/main/java/com/icando/paragraphCompletion/exception/ParagraphCompletionException.java
+++ b/src/main/java/com/icando/paragraphCompletion/exception/ParagraphCompletionException.java
@@ -1,0 +1,10 @@
+package com.icando.paragraphCompletion.exception;
+
+import com.icando.global.error.core.BaseException;
+import com.icando.global.error.core.ErrorCode;
+
+public class ParagraphCompletionException extends BaseException {
+    public ParagraphCompletionException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/icando/paragraphCompletion/repository/ParagraphCompletionRepository.java
+++ b/src/main/java/com/icando/paragraphCompletion/repository/ParagraphCompletionRepository.java
@@ -1,9 +1,13 @@
 package com.icando.paragraphCompletion.repository;
 
+import com.icando.member.entity.Member;
 import com.icando.paragraphCompletion.entity.ParagraphCompletion;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ParagraphCompletionRepository extends JpaRepository<ParagraphCompletion,Long> {
+    Optional<ParagraphCompletion> findByIdAndMember(Long id, Member member);
 }

--- a/src/main/java/com/icando/paragraphCompletion/repository/ParagraphWordRepository.java
+++ b/src/main/java/com/icando/paragraphCompletion/repository/ParagraphWordRepository.java
@@ -1,0 +1,7 @@
+package com.icando.paragraphCompletion.repository;
+
+import com.icando.paragraphCompletion.entity.ParagraphWord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParagraphWordRepository extends JpaRepository<ParagraphWord, Long> {
+}

--- a/src/main/java/com/icando/paragraphCompletion/service/ParagraphCompletionService.java
+++ b/src/main/java/com/icando/paragraphCompletion/service/ParagraphCompletionService.java
@@ -1,13 +1,24 @@
 package com.icando.paragraphCompletion.service;
 
+import com.icando.global.error.core.ErrorCode;
+import com.icando.member.entity.Member;
+import com.icando.member.repository.MemberRepository;
+import com.icando.paragraphCompletion.dto.ParagraphCompletionRequest;
+import com.icando.paragraphCompletion.dto.ParagraphCompletionResponse;
+import com.icando.paragraphCompletion.entity.ParagraphCompletion;
+import com.icando.paragraphCompletion.entity.ParagraphWord;
 import com.icando.paragraphCompletion.entity.WordSetItem;
+import com.icando.paragraphCompletion.exception.ParagraphCompletionErrorCode;
+import com.icando.paragraphCompletion.exception.ParagraphCompletionException;
 import com.icando.paragraphCompletion.repository.ParagraphCompletionRepository;
+import com.icando.paragraphCompletion.repository.ParagraphWordRepository;
 import com.icando.paragraphCompletion.repository.WordSetItemRepository;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -15,15 +26,57 @@ public class ParagraphCompletionService {
     private final ParagraphCompletionRepository paragraphCompletionRepository;
     private final WordSetItemRepository wordSetItemRepository;
     private final ChatClient ai;
+    private final MemberRepository memberRepository;
+    private final ParagraphWordRepository paragraphWordRepository;
 
-    
-    public ParagraphCompletionService(ParagraphCompletionRepository paragraphCompletionRepository, WordSetItemRepository wordSetItemRepository, ChatClient.Builder chatClient) {
+
+    public ParagraphCompletionService(ParagraphCompletionRepository paragraphCompletionRepository, WordSetItemRepository wordSetItemRepository, ChatClient.Builder chatClient, MemberRepository memberRepository, ParagraphWordRepository paragraphWordRepository) {
         this.paragraphCompletionRepository = paragraphCompletionRepository;
         this.wordSetItemRepository = wordSetItemRepository;
         this.ai = chatClient.build();
+        this.memberRepository = memberRepository;
+        this.paragraphWordRepository = paragraphWordRepository;
     }
 
     public List<String> generateWords(int count) {
         return wordSetItemRepository.getRandomWords(count).stream().map(WordSetItem::getWord).toList();
+    }
+
+    @Transactional
+    public ParagraphCompletionResponse insertParagraphCompletionArticle(Long memberId, ParagraphCompletionRequest paragraphCompletionRequest) {
+        if (paragraphCompletionRequest.getWords() == null || paragraphCompletionRequest.getWords().isEmpty()) {
+            throw new ParagraphCompletionException(ParagraphCompletionErrorCode.INVALID_WORD_COUNT);
+        }
+
+        if (paragraphCompletionRequest.getContent() == null || paragraphCompletionRequest.getContent().isEmpty()) {
+            throw new ParagraphCompletionException(ParagraphCompletionErrorCode.INVALID_CONTENT);
+        }
+
+        paragraphCompletionRequest.getWords().forEach(word -> {
+            if (!paragraphCompletionRequest.getContent().contains(word)) {
+                throw new ParagraphCompletionException(ParagraphCompletionErrorCode.WORD_NOT_IN_CONTENT);
+            }
+        });
+
+        Optional<Member> member = memberRepository.findById(memberId);
+        if (member.isEmpty()) {
+            throw new ParagraphCompletionException(ParagraphCompletionErrorCode.USER_NOT_FOUND);
+        }
+
+        ParagraphCompletion paragraphCompletion = ParagraphCompletion.of(
+                paragraphCompletionRequest.getContent(),
+                member.get()
+        );
+
+        List<ParagraphWord> paragraphWords = paragraphCompletionRequest.getWords().stream()
+                .map(word -> ParagraphWord.of(word, paragraphCompletion))
+                .toList();
+        paragraphCompletion.getParagraphWords().addAll(paragraphWords);
+
+        ParagraphCompletion savedParagraphCompletion = paragraphCompletionRepository.save(paragraphCompletion);
+
+        paragraphWordRepository.saveAll(paragraphWords);
+
+        return ParagraphCompletionResponse.of(savedParagraphCompletion);
     }
 }

--- a/src/main/java/com/icando/paragraphCompletion/service/ParagraphCompletionService.java
+++ b/src/main/java/com/icando/paragraphCompletion/service/ParagraphCompletionService.java
@@ -79,4 +79,15 @@ public class ParagraphCompletionService {
 
         return ParagraphCompletionResponse.of(savedParagraphCompletion);
     }
+
+    public ParagraphCompletionResponse getParagraphCompletionArticle(Long userId, Long id) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new ParagraphCompletionException(ParagraphCompletionErrorCode.USER_NOT_FOUND));
+
+        ParagraphCompletion paragraphCompletion = paragraphCompletionRepository.findByIdAndMember(id, member)
+                .orElseThrow(() -> new ParagraphCompletionException(ParagraphCompletionErrorCode.PARAGRAPH_COMPLETION_NOT_FOUND));
+        // TODO: Feedback 넣고 FetchJoin 해야함
+
+        return ParagraphCompletionResponse.of(paragraphCompletion);
+    }
 }

--- a/src/main/java/com/icando/paragraphCompletion/service/ParagraphCompletionService.java
+++ b/src/main/java/com/icando/paragraphCompletion/service/ParagraphCompletionService.java
@@ -1,6 +1,5 @@
 package com.icando.paragraphCompletion.service;
 
-import com.icando.global.error.core.ErrorCode;
 import com.icando.member.entity.Member;
 import com.icando.member.repository.MemberRepository;
 import com.icando.paragraphCompletion.dto.ParagraphCompletionRequest;

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -5697,3 +5697,7 @@ INSERT INTO word_set_item(word) VALUES ('힘들어하다');
 INSERT INTO word_set_item(word) VALUES ('힘쓰다');
 INSERT INTO word_set_item(word) VALUES ('힘없이');
 INSERT INTO word_set_item(word) VALUES ('힘차다');
+
+INSERT INTO mbti(mbti_id, mbti_name, mbti_description, mbti_iamage_url, is_deleted, created_at, modified_at) VALUES (1, 'TEST', '테스트용 MBTI', 'https://example.com/test.png', false, '2023-10-01 00:00:00', '2023-10-01 00:00:00');
+INSERT INTO member(member_id, is_deleted, created_at, mbti_id, modified_at, member_email, member_name, member_password, member_provider, member_provider_id, role) VALUES
+(1, false, '2023-10-01 00:00:00', 1, '2023-10-01 00:00:00', 'test@test.com', '테스트', '$2a$10$E9z1b5Z3k7Q8Y1f4e5d6uO0j1F8c5J3m5Z1b5Z3k7Q8Y1f4e5d6uO', 'local', 'test', 'ROLE_USER');

--- a/src/test/java/com/icando/paragraphCompletion/service/ParagraphCompletionServiceTest.java
+++ b/src/test/java/com/icando/paragraphCompletion/service/ParagraphCompletionServiceTest.java
@@ -1,17 +1,26 @@
 package com.icando.paragraphCompletion.service;
 
+import com.icando.member.entity.Member;
+import com.icando.member.repository.MemberRepository;
+import com.icando.paragraphCompletion.dto.ParagraphCompletionRequest;
+import com.icando.paragraphCompletion.dto.ParagraphCompletionResponse;
+import com.icando.paragraphCompletion.entity.ParagraphCompletion;
+import com.icando.paragraphCompletion.entity.ParagraphWord;
 import com.icando.paragraphCompletion.entity.WordSetItem;
 import com.icando.paragraphCompletion.repository.ParagraphCompletionRepository;
+import com.icando.paragraphCompletion.repository.ParagraphWordRepository;
 import com.icando.paragraphCompletion.repository.WordSetItemRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.ai.chat.client.ChatClient;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -26,21 +35,23 @@ class ParagraphCompletionServiceTest {
     private WordSetItemRepository wordSetItemRepository;
 
     @Mock
+    private ParagraphWordRepository paragraphWordRepository;
+
+    @Mock
     private ChatClient.Builder chatClientBuilder;
 
     @Mock
     private ChatClient chatClient;
 
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
     private ParagraphCompletionService paragraphCompletionService;
 
     @BeforeEach
     void setUp() {
-        when(chatClientBuilder.build()).thenReturn(chatClient);
-        paragraphCompletionService = new ParagraphCompletionService(
-            paragraphCompletionRepository,
-            wordSetItemRepository,
-            chatClientBuilder
-        );
+//        when(chatClientBuilder.build()).thenReturn(chatClient);
     }
 
     @Test
@@ -105,5 +116,114 @@ class ParagraphCompletionServiceTest {
 //        when(wordSetItem.getId()).thenReturn(id);
         when(wordSetItem.getWord()).thenReturn(word);
         return wordSetItem;
+    }
+
+    @Test
+    @DisplayName("문장 완성 글쓰기 성공")
+    void insertParagraphCompletionArticle_Success() {
+        // given
+        Member mb1 = mock(Member.class);
+        when(mb1.getId()).thenReturn(1L);
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mb1));
+        ParagraphCompletionRequest req = createParagraphCompletionRequest("이것은 테스트 문장입니다.", List.of("테스트", "문장", "입니다"));
+        ParagraphCompletion pc = createParagraphCompletion("이것은 테스트 문장입니다.", List.of("테스트", "문장", "입니다"));
+
+        when(pc.getContent()).thenReturn("이것은 테스트 문장입니다.");
+        when(paragraphCompletionRepository.save(any())).thenReturn(pc);
+
+        // when & then
+        paragraphCompletionService.insertParagraphCompletionArticle(mb1.getId(), req);
+
+        assertEquals(req.getContent(), pc.getContent());
+        assertEquals(3, pc.getParagraphWords().size());
+
+        verify(memberRepository, times(1)).findById(anyLong());
+        verify(paragraphCompletionRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("단어가 문장에 포함되지 않은 경우 예외 발생")
+    void insertParagraphCompletionArticle_WordNotInContent() {
+        // given
+        Member mb1 = mock(Member.class);
+        when(mb1.getId()).thenReturn(1L);
+        ParagraphCompletionRequest req = createParagraphCompletionRequest("이것은 테스트 문장입니다.", List.of("테스트", "없는단어"));
+        // when & then
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            paragraphCompletionService.insertParagraphCompletionArticle(mb1.getId(), req);
+        });
+        assertEquals("내용에 포함되어 있지 않은 단어가 있습니다.", exception.getMessage());
+        verify(memberRepository, times(0)).findById(anyLong());
+        verify(paragraphCompletionRepository, times(0)).save(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원일 경우 예외 발생")
+    void insertParagraphCompletionArticle_UserNotFound() {
+        // given
+        Long nonExistentUserId = 999L;
+        when(memberRepository.findById(nonExistentUserId)).thenReturn(Optional.empty());
+        ParagraphCompletionRequest req = createParagraphCompletionRequest("이것은 테스트 문장입니다.", List.of("테스트", "문장"));
+        // when & then
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            paragraphCompletionService.insertParagraphCompletionArticle(nonExistentUserId, req);
+        });
+        assertEquals("사용자를 찾을 수 없습니다.", exception.getMessage());
+        verify(memberRepository, times(1)).findById(nonExistentUserId);
+        verify(paragraphCompletionRepository, times(0)).save(any());
+    }
+
+    @Test
+    @DisplayName("빈 단어 리스트로 문장 완성 글쓰기 시도")
+    void insertParagraphCompletionArticle_EmptyContentAndWords() {
+        // given
+        ParagraphCompletionRequest req = createParagraphCompletionRequest("", List.of());
+        // when & then
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            paragraphCompletionService.insertParagraphCompletionArticle(1L, req);
+        });
+        assertEquals("단어 목록이 비어있습니다.", exception.getMessage());
+        verify(memberRepository, times(0)).findById(anyLong());
+        verify(paragraphCompletionRepository, times(0)).save(any());
+    }
+
+    @Test
+    @DisplayName("빈 문장으로 문장 완성 글쓰기 시도")
+    void insertParagraphCompletionArticle_EmptyContent() {
+        // given
+        ParagraphCompletionRequest req = createParagraphCompletionRequest("", List.of("테스트", "문장"));
+        // when & then
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            paragraphCompletionService.insertParagraphCompletionArticle(1L, req);
+        });
+        assertEquals("내용이 비어있습니다.", exception.getMessage());
+        verify(memberRepository, times(0)).findById(anyLong());
+        verify(paragraphCompletionRepository, times(0)).save(any());
+    }
+
+    @Test
+
+
+    private ParagraphCompletionRequest createParagraphCompletionRequest(String content, List<String> words) {
+        ParagraphCompletionRequest request = mock(ParagraphCompletionRequest.class);
+        if (content != null && !content.isEmpty()) {
+            when(request.getContent()).thenReturn(content);
+        }
+        if (words != null && !words.isEmpty()) {
+            when(request.getWords()).thenReturn(words);
+        }
+        return request;
+    }
+
+    private ParagraphCompletion createParagraphCompletion(String content, List<String> words) {
+        ParagraphCompletion pc = mock(ParagraphCompletion.class);
+        when(pc.getContent()).thenReturn(content);
+        var pwList = words.stream().map(word -> {
+            var pw = mock(ParagraphWord.class);
+            when(pw.getWord()).thenReturn(word);
+            return pw;
+        }).toList();
+        when(pc.getParagraphWords()).thenReturn(pwList);
+        return pc;
     }
 }

--- a/src/test/java/com/icando/paragraphCompletion/service/ParagraphCompletionServiceTest.java
+++ b/src/test/java/com/icando/paragraphCompletion/service/ParagraphCompletionServiceTest.java
@@ -201,9 +201,6 @@ class ParagraphCompletionServiceTest {
         verify(paragraphCompletionRepository, times(0)).save(any());
     }
 
-    @Test
-
-
     private ParagraphCompletionRequest createParagraphCompletionRequest(String content, List<String> words) {
         ParagraphCompletionRequest request = mock(ParagraphCompletionRequest.class);
         if (content != null && !content.isEmpty()) {


### PR DESCRIPTION
## 📌 개요
- 문장완성 도메인에서 사용자가 작성한 글을 조회할 수 있는 기능이 추가되었습니다.

## 🛠️ 작업 내용
- 컨트롤러, 서비스에 글을 조회할 수 있는 기능이 추가 되었습니다.
- 리포지토리에서 글을 조회할 때 작성자를 확인해야 글을 반환하도록 하였습니다.
- 테스트에서 하드코딩 된 예외 메시지 처리를 enum.getMessage()를 사용하도록 수정했습니다.
- 글 조회 기능에 대한 테스트가 추가되었습니다.


## 📌 차후 계획

TODO: Response DTO에 Feedback을 추가해야합니다.
TODO: 로그인 기능 구현시 UserDetails에서 사용자 id를 가져와 임시 값이 들어간 userId 부분을 실제 값이 들어가도록 설정해야합니다.

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [ ] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등
PostTest가 작동하지 않습니다.
Member.createLocalMember가  Member.of 로 바뀐 영향인 듯 합니다.
---

closes #44

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.