### PR TITLE
[Feat] 회원탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/icando/member/controller/MemberController.java
+++ b/src/main/java/com/icando/member/controller/MemberController.java
@@ -7,23 +7,16 @@ import com.icando.member.dto.MyPageResponse;
 import com.icando.member.dto.PointHistoryResponse;
 import com.icando.member.exception.MemberSuccessCode;
 import com.icando.member.service.MemberService;
-import com.icando.global.success.SuccessCode;
-import com.icando.global.success.SuccessResponse;
 import com.icando.member.dto.MbtiRequest;
-import com.icando.member.exception.MemberSuccessCode;
 import com.icando.member.service.MbtiService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -103,7 +96,7 @@ public class MemberController {
             summary = "회원탈퇴",
             description = "회원탈퇴를 할 수 있는 컨트롤러입니다."
     )
-    @PostMapping("/delete")
+    @DeleteMapping
     public ResponseEntity<SuccessResponse> deleteMember(
             @AuthenticationPrincipal UserDetails userDetails
     ) {

--- a/src/main/java/com/icando/member/controller/MemberController.java
+++ b/src/main/java/com/icando/member/controller/MemberController.java
@@ -98,5 +98,19 @@ public class MemberController {
                 SuccessResponse.of(MemberSuccessCode.POINT_SUCCESS_SEARCH, response)
         );
     }
+
+    @Operation(
+            summary = "회원탈퇴",
+            description = "회원탈퇴를 할 수 있는 컨트롤러입니다."
+    )
+    @PostMapping("/delete")
+    public ResponseEntity<SuccessResponse> deleteMember(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        memberService.deleteMember(userDetails.getUsername());
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(MemberSuccessCode.MEMBER_SUCCESS_DELETED));
+    }
 }
 

--- a/src/main/java/com/icando/member/exception/MemberSuccessCode.java
+++ b/src/main/java/com/icando/member/exception/MemberSuccessCode.java
@@ -11,7 +11,8 @@ public enum MemberSuccessCode implements SuccessCode {
     MYPAGE_SUCCESS_FOUND(HttpStatus.OK, "마이페이지를 성공적으로 조회하였습니다."),
     MBTI_SUCCESS_SAVE(HttpStatus.CREATED, "MBTI 저장이 성공했습니다."),
     POINT_SUCCESS_SEARCH(HttpStatus.OK, "POINT를 성공적으로 조회하였습니다."),
-    MBTI_SUCCESS_FOUND(HttpStatus.OK, "MBTI 조회를 성공했습니다.");
+    MBTI_SUCCESS_FOUND(HttpStatus.OK, "MBTI 조회를 성공했습니다."),
+    MEMBER_SUCCESS_DELETED(HttpStatus.OK, "회원탈퇴를 성공적으로 완료했습니다.");
     private final HttpStatus status;
     private final String message;
 

--- a/src/main/java/com/icando/member/login/service/LoginService.java
+++ b/src/main/java/com/icando/member/login/service/LoginService.java
@@ -68,12 +68,4 @@ public class LoginService implements UserDetailsService {
                 .roles(member.getRole().name())
                 .build();
     }
-
-    
-
-
-
-
-
-
 }

--- a/src/main/java/com/icando/member/repository/MbtiRepository.java
+++ b/src/main/java/com/icando/member/repository/MbtiRepository.java
@@ -3,6 +3,9 @@ package com.icando.member.repository;
 import com.icando.member.entity.Mbti;
 import com.icando.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,4 +17,8 @@ public interface MbtiRepository extends JpaRepository<Mbti,Long> {
     Optional<Mbti> findByName(String name);
     List<Mbti> findAllByMemberId(Long memberId);
     Boolean existsByMemberAndName(Member member, String name);
+
+    @Modifying
+    @Query("DELETE FROM Mbti m WHERE m.member.id = :memberId")
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/icando/member/repository/MbtiRepository.java
+++ b/src/main/java/com/icando/member/repository/MbtiRepository.java
@@ -18,7 +18,7 @@ public interface MbtiRepository extends JpaRepository<Mbti,Long> {
     List<Mbti> findAllByMemberId(Long memberId);
     Boolean existsByMemberAndName(Member member, String name);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Mbti m WHERE m.member.id = :memberId")
     void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/icando/member/service/MemberService.java
+++ b/src/main/java/com/icando/member/service/MemberService.java
@@ -8,6 +8,8 @@ import com.icando.member.entity.Mbti;
 import com.icando.member.entity.Member;
 import com.icando.member.exception.MemberErrorCode;
 import com.icando.member.exception.MemberException;
+import com.icando.member.login.exception.AuthErrorCode;
+import com.icando.member.login.exception.AuthException;
 import com.icando.member.repository.MbtiRepository;
 import com.icando.member.repository.MemberRepository;
 import com.icando.member.repository.PointHistoryRepository;
@@ -84,6 +86,13 @@ public class MemberService {
         );
         return member;
 
+    }
+
+    public void deleteMember(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.EMAIL_INVALID));
+        mbtiRepository.deleteAllByMemberId(member.getId());
+        memberRepository.delete(member);
     }
 }
 


### PR DESCRIPTION
## 📌 개요

- ManyToOne으로 mbti와 연관관계가 맺혀있기에 Member 삭제 전, MBTI삭제
(findAll()로 찾아와서 삭제를 진행하면 쓸데없는 조회가 일어날것 같아 쿼리문 작성)
- ClearAutomatically = true -> delete, update쿼리문을 작성하면, JPA 라이프사이클을 무시하여 영속성 컨텍스트가 DB의 변경
사항을 알아차리지 못한다고하여 clearAutomatically = true를 통해 동기화 시켜줌.
- softDelete 를 사용하기로 하였지만, 현재 회원탈퇴 후 재가입을 한다는 가정에 회원 중복 예외처리등이 email로 기준이 잡혀있어
회원탈퇴 후에 email값을 UUID를 사용하여 랜덤값으로 바꾸는 방법도 있지만, 일단 hardDelete를 사용하여 로직 작성하였습니다.
의견 있으신 분 남겨주시면 반영하도록 하겠습니다.

## 🛠️ 작업 내용
- [ ] 변경 사항 요약
- [ ] 주요 변경 사항 설명
- [ ] 관련 이슈 번호 (`#이슈번호`)

## 📌 테스트 케이스
- [ ] 기능 정상 동작 확인
- [ ] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [ ] 코드 스타일 및 컨벤션 준수 확인
- [ ] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.