### PR TITLE
[Refactor] 회원가입 시, LOCAL로 변경 + 회원탈퇴 시 연관된 엔티티삭제

### DIFF
--- a/src/main/java/com/icando/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/icando/bookmark/repository/BookmarkRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -24,4 +25,6 @@ WHERE b.member = :member
     Page<Bookmark> findAllByMember(Member member, Pageable pageable);
 
     Optional<Bookmark> findBookmarkByIdAndMember(Long id, Member member);
+
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/icando/member/entity/Member.java
+++ b/src/main/java/com/icando/member/entity/Member.java
@@ -79,8 +79,8 @@ public class Member extends BaseEntity {
         return new Member(id, name, email, password, null, null, false, role);
     }
 
-    public void updateVerify() {
-        this.isVerified = true;
+    public void updateProvide() {
+        this.provider = Provider.LOCAL;
     }
 
     public void addPoints(int getPoint) {

--- a/src/main/java/com/icando/member/entity/Member.java
+++ b/src/main/java/com/icando/member/entity/Member.java
@@ -37,9 +37,6 @@ public class Member extends BaseEntity {
     @Column(name = "member_provider_id")
     private String providerId;
 
-    @Column(name = "is_verified")
-    private Boolean isVerified = false;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
     private Role role = Role.USER;
@@ -49,34 +46,32 @@ public class Member extends BaseEntity {
     private int totalPoint;
 
     private Member(String name, String email,String password,Provider provider,
-                   String providerId, Boolean isVerified, Role role) {
+                   String providerId, Role role) {
         this.name = name;
         this.email = email;
         this.password = password;
         this.provider = provider;
         this.providerId = providerId;
-        this.isVerified = isVerified;
         this.role = role;
     }
     private Member(Long id ,String name, String email,String password,Provider provider,
-                    String providerId, Boolean isVerified, Role role) {
+                    String providerId, Role role) {
         this.name = name;
         this.email = email;
         this.password = password;
         this.provider = provider;
         this.providerId = providerId;
-        this.isVerified = isVerified;
         this.role = role;
     }
 
     //로컬 자체로그인 회원 객체 생성
-    public static Member createLocalMember(String name, String email,String password, Role role, Boolean isVerified) {
-        return new Member(name, email, password, null, null, false, role);
+    public static Member createLocalMember(String name, String email,String password, Role role) {
+        return new Member(name, email, password, null, null,  role);
     }
 
-    public static Member createLocalMemberByTest(Long id,String name, String email,String password, Role role, Boolean isVerified) {
+    public static Member createLocalMemberByTest(Long id,String name, String email,String password, Role role) {
 
-        return new Member(id, name, email, password, null, null, false, role);
+        return new Member(id, name, email, password, null, null,  role);
     }
 
     public void updateProvide() {

--- a/src/main/java/com/icando/member/login/service/LoginService.java
+++ b/src/main/java/com/icando/member/login/service/LoginService.java
@@ -50,6 +50,7 @@ public class LoginService implements UserDetailsService {
                 false
         );
 
+        member.updateProvide();
         memberRepository.save(member);
         redisUtil.deleteData("verified:" + member.getEmail());
 

--- a/src/main/java/com/icando/member/login/service/LoginService.java
+++ b/src/main/java/com/icando/member/login/service/LoginService.java
@@ -46,8 +46,7 @@ public class LoginService implements UserDetailsService {
                 joinDto.getName(),
                 joinDto.getEmail(),
                 bCryptPasswordEncoder.encode(joinDto.getPassword()),
-                Role.valueOf(Role.USER.name()),
-                false
+                Role.valueOf(Role.USER.name())
         );
 
         member.updateProvide();

--- a/src/main/java/com/icando/member/repository/PointHistoryRepository.java
+++ b/src/main/java/com/icando/member/repository/PointHistoryRepository.java
@@ -2,6 +2,7 @@ package com.icando.member.repository;
 
 import com.icando.member.entity.PointHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -14,5 +15,6 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory,Long>
     int countByMemberIdAndCreatedAt(Long memberId, LocalDate today);
     List<PointHistory> findAllByMemberId(Long memberId);
     List<PointHistory> findByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime startOfDay, LocalDateTime endOfDay);
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 
 }

--- a/src/main/java/com/icando/member/service/MemberService.java
+++ b/src/main/java/com/icando/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.icando.member.service;
 
+import com.icando.bookmark.repository.BookmarkRepository;
 import com.icando.member.dto.MbtiResponse;
 import com.icando.member.dto.MbtiSummaryDto;
 import com.icando.member.dto.MyPageResponse;
@@ -13,6 +14,8 @@ import com.icando.member.login.exception.AuthException;
 import com.icando.member.repository.MbtiRepository;
 import com.icando.member.repository.MemberRepository;
 import com.icando.member.repository.PointHistoryRepository;
+import com.icando.paragraphCompletion.repository.ParagraphCompletionRepository;
+import com.icando.writing.repository.WritingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +31,9 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final MbtiRepository mbtiRepository;
     private final PointHistoryRepository pointHistoryRepository;
+    private final WritingRepository writingRepository;
+    private final ParagraphCompletionRepository paragraphCompletionRepository;
+    private final BookmarkRepository bookmarkRepository;
 
     public MyPageResponse searchMyPage(String email) {
 
@@ -92,7 +98,13 @@ public class MemberService {
     public void deleteMember(String email) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.MEMBER_NOT_FOUND));
+
         mbtiRepository.deleteAllByMemberId(member.getId());
+        writingRepository.deleteAllByMemberId(member.getId());
+        pointHistoryRepository.deleteAllByMemberId(member.getId());
+        paragraphCompletionRepository.deleteAllByMemberId(member.getId());
+        bookmarkRepository.deleteAllByMemberId(member.getId());
+
         memberRepository.delete(member);
     }
 }

--- a/src/main/java/com/icando/paragraphCompletion/repository/ParagraphCompletionRepository.java
+++ b/src/main/java/com/icando/paragraphCompletion/repository/ParagraphCompletionRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -29,4 +30,6 @@ public interface ParagraphCompletionRepository extends JpaRepository<ParagraphCo
         WHERE pc.member = :member
 """)
     Page<ParagraphCompletion> findAllByMember(Member member, Pageable pageable);
+
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/icando/writing/repository/WritingRepository.java
+++ b/src/main/java/com/icando/writing/repository/WritingRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,4 +18,6 @@ public interface WritingRepository extends JpaRepository<Writing, Long> {
         WHERE w.member = :member
     """)
     Page<Writing> findAllByMember(Member member, Pageable pageable);
+
+    void deleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/test/java/com/icando/ICanDoApplicationTests.java
+++ b/src/test/java/com/icando/ICanDoApplicationTests.java
@@ -2,8 +2,10 @@ package com.icando;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class ICanDoApplicationTests {
 
     @Test

--- a/src/test/java/com/icando/ItemShop/AdminPointHistoryShopTest.java
+++ b/src/test/java/com/icando/ItemShop/AdminPointHistoryShopTest.java
@@ -56,8 +56,7 @@ public class AdminPointHistoryShopTest {
             "user1",
             "user@example.com",
             "1234",
-            Role.ADMIN,
-            false
+            Role.ADMIN
         );
 
         when(memberRepository.findByEmail("user@example.com"))

--- a/src/test/java/com/icando/ItemShop/UserPointHistoryShopTest.java
+++ b/src/test/java/com/icando/ItemShop/UserPointHistoryShopTest.java
@@ -80,16 +80,14 @@ public class UserPointHistoryShopTest {
                 "user1",
                 "user@example.com",
                 "1234",
-                Role.USER,
-                false
+                Role.USER
         );
         admin = Member.createLocalMemberByTest(
                 2L,
                 "admin",
                 "admin@example.com",
                 "1234",
-                Role.ADMIN,
-                false
+                Role.ADMIN
         );
 
     }

--- a/src/test/java/com/icando/feedback/service/FeedbackServiceTest.java
+++ b/src/test/java/com/icando/feedback/service/FeedbackServiceTest.java
@@ -65,8 +65,7 @@ class FeedbackServiceTest {
             "name",
             "test@exampl.com",
             "1234",
-            Role.USER,
-            false
+            Role.USER
         );
     }
 

--- a/src/test/java/com/icando/login/LoginTest.java
+++ b/src/test/java/com/icando/login/LoginTest.java
@@ -39,8 +39,7 @@ public class LoginTest {
                 "최다빈",
                 "9636515@test.com",
                 "test123",
-                Role.USER,
-                false
+                Role.USER
         );
     }
     @Test

--- a/src/test/java/com/icando/login/LogoutTest.java
+++ b/src/test/java/com/icando/login/LogoutTest.java
@@ -39,8 +39,7 @@ public class LogoutTest {
               "최다빈",
               "9636515@test.com",
               "test123",
-              Role.USER,
-              false
+              Role.USER
         );
     }
 

--- a/src/test/java/com/icando/member/mbti/MbtiServiceTest.java
+++ b/src/test/java/com/icando/member/mbti/MbtiServiceTest.java
@@ -47,8 +47,7 @@ public class MbtiServiceTest {
             "name",
             "test@exampl.com",
             "1234",
-            Role.USER,
-            false
+            Role.USER
         );
 
         mbtiRequest = new MbtiRequest("ISTP", "ISTP ", "ISTP.png");

--- a/src/test/java/com/icando/member/mypage/MypageTest.java
+++ b/src/test/java/com/icando/member/mypage/MypageTest.java
@@ -47,8 +47,7 @@ public class MypageTest {
                 "최다빈",
                 "9636515@test.com",
                 "test123",
-                Role.USER,
-                false
+                Role.USER
         );
         ReflectionTestUtils.setField(member, "id", 1L);
     }

--- a/src/test/java/com/icando/writing/service/WritingServiceTest.java
+++ b/src/test/java/com/icando/writing/service/WritingServiceTest.java
@@ -54,8 +54,7 @@ class WritingServiceTest {
             "testuser",
             email,
             "password",
-            Role.USER,
-            false
+            Role.USER
         );
         Topic mockTopic = Topic.of(null, "테스트 주제");
         Writing mockWriting = mock(Writing.class);
@@ -112,8 +111,7 @@ class WritingServiceTest {
             "testuser",
             email,
             "password",
-            Role.USER,
-            false
+            Role.USER
         );
         when(memberRepository.findByEmail(email)).thenReturn(Optional.of(mockMember));
         when(topicRepository.findById(topicId)).thenReturn(Optional.empty());


### PR DESCRIPTION
## 🛠️ 작업 내용
- [ ] 자체 회원 가입시 Provider=null로 들어오는 문제, provider : LOCAL로 되도록 수정
- [ ] is_verified 컬럼 삭제 -> 테스트 코드도 수정완료
- [ ] 회원가입 시 연관된 엔티티 먼저 삭제 후, Member 삭제


- 회원가입 탈퇴 시 현재 OneToMany로 MemberEntity에 걸려있지않고, 다른 엔티티에 ManyToOne으로 되어있는 상태라 CASCADE이용 불가
- @SoftDelete처리를 하려고 보니 모든 엔티티에@Where(clause = "member_id IN (SELECT id FROM member WHERE deleted = false)")처리를 통해 false인 멤버만 불러오게 가능 -> 근데 Mbti, Point, Writing 굳이 남겨둘 필요가 보안상, 내용의 중요성면으로 봤을 때 없다고 판단 
- CasCade로 코드 간편화 가능화하려면 -> Member Entity에 OneToMany다 걸어두고 처리하면 코드는 간편해짐 ( 이거 엔티티 수정 할 수 있는 사람만 반박하도록)
- 그래서 그냥 deleteAllByMemberId를 통해 Member와 연관된 엔티티 먼저 삭제 후, Member hardDelete로 수정하였슴

### Entity수정하기에는 너무나 많은 시간 소요, 시간 부족등의 이유로 모든 엔티티 @Where절 걸바에 그냥 다 HardDelete처리 한것입니다. 반박시 당신말이 맞습니다 수정할게요 의견주세요

