### PR TITLE
[Fix] 하나의 상품에 대해서 동시에 구매 시 락 추가

### DIFF
--- a/src/main/java/com/icando/ItemShop/repository/ItemRepository.java
+++ b/src/main/java/com/icando/ItemShop/repository/ItemRepository.java
@@ -1,9 +1,19 @@
 package com.icando.ItemShop.repository;
 
 import com.icando.ItemShop.entity.Item;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface ItemRepository extends JpaRepository<Item, Long>,ItemRepositoryCustom {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select i from Item i where  i.id = :itemId")
+    Optional<Item> findByIdWithLock(@Param("itemId") Long itemId);
 }

--- a/src/main/java/com/icando/ItemShop/service/UserPointShopService.java
+++ b/src/main/java/com/icando/ItemShop/service/UserPointShopService.java
@@ -181,7 +181,8 @@ public class UserPointShopService {
 
     @Transactional
     public Item buyItem(Long itemId,String number, String email) {
-        Item item = validateItem(itemId);
+        Item item = itemRepository.findByIdWithLock(itemId)
+                .orElseThrow(()-> new PointShopException(PointShopErrorCode.INVALID_ITEM_ID));
         if (item.getQuantity() <= 0) {
             throw new PointShopException(PointShopErrorCode.OUT_OF_STOCK);
         }

--- a/src/main/java/com/icando/ItemShop/service/UserPointShopService.java
+++ b/src/main/java/com/icando/ItemShop/service/UserPointShopService.java
@@ -182,6 +182,10 @@ public class UserPointShopService {
     @Transactional
     public Item buyItem(Long itemId,String number, String email) {
         Item item = validateItem(itemId);
+        if (item.getQuantity() <= 0) {
+            throw new PointShopException(PointShopErrorCode.OUT_OF_STOCK);
+        }
+
         Member member = validatePoint(email, item.getPoint());
         PointShopHistory pointShopHistory = PointShopHistory.byPhoneNumber(member,item,number);
         pointService.usePoint(member,item.getPoint(), ActivityType.BUY);

--- a/src/main/java/com/icando/member/entity/Member.java
+++ b/src/main/java/com/icando/member/entity/Member.java
@@ -43,7 +43,7 @@ public class Member extends BaseEntity {
 
     @Column(name = "member_total_point")
     @ColumnDefault("0")
-    private int totalPoint;
+    private Integer totalPoint;
 
     private Member(String name, String email,String password,Provider provider,
                    String providerId, Role role) {
@@ -64,6 +64,17 @@ public class Member extends BaseEntity {
         this.role = role;
     }
 
+    private Member(String name, String email,String password,Provider provider,
+                   String providerId, Role role,Integer totalPoint) {
+        this.name = name;
+        this.email = email;
+        this.password = password;
+        this.provider = provider;
+        this.providerId = providerId;
+        this.role = role;
+        this.totalPoint = totalPoint;
+    }
+
     //로컬 자체로그인 회원 객체 생성
     public static Member createLocalMember(String name, String email,String password, Role role) {
         return new Member(name, email, password, null, null,  role);
@@ -72,6 +83,11 @@ public class Member extends BaseEntity {
     public static Member createLocalMemberByTest(Long id,String name, String email,String password, Role role) {
 
         return new Member(id, name, email, password, null, null,  role);
+    }
+
+    public static Member createLocalMemberByTestByPoint(String name, String email, String password, Role role, Integer totalPoint) {
+
+        return new Member(name, email, password, null, null,  role, totalPoint);
     }
 
     public void updateProvide() {

--- a/src/main/java/com/icando/member/entity/PointHistory.java
+++ b/src/main/java/com/icando/member/entity/PointHistory.java
@@ -1,14 +1,11 @@
 package com.icando.member.entity;
 
 import com.icando.global.BaseEntity;
-import com.icando.member.exception.MemberErrorCode;
-import com.icando.member.exception.MemberException;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -27,7 +24,7 @@ public class PointHistory extends BaseEntity {
     @Column(name = "points")
     private int points;
 
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     @Column(name = "point_activity_type")
     private ActivityType activityType;
 

--- a/src/test/java/com/icando/ItemShop/UserPointShopTest.java
+++ b/src/test/java/com/icando/ItemShop/UserPointShopTest.java
@@ -93,10 +93,10 @@ public class UserPointShopTest {
     }
 
     @Test
-    @DisplayName("동시성 환경 10000명 동시 상품 구매 재고 차감 테스트")
+    @DisplayName("동시성 환경 1000명 동시 상품 구매 재고 차감 테스트")
     public void buy_1000_together() throws InterruptedException {
         //given
-        int threadCount = 10000;
+        int threadCount = 1000;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
 
@@ -141,7 +141,7 @@ public class UserPointShopTest {
         System.out.println("실패 횟수:" + failCount.get());
         System.out.println("성공 횟수:" + successCount.get());
         assertThat(updatedItem.getQuantity()).isZero();
-        assertThat(failCount.get()).isEqualTo(9900);
+        assertThat(failCount.get()).isEqualTo(900);
         assertThat(successCount.get()).isEqualTo(100);
 
 

--- a/src/test/java/com/icando/ItemShop/UserPointShopTest.java
+++ b/src/test/java/com/icando/ItemShop/UserPointShopTest.java
@@ -1,0 +1,150 @@
+package com.icando.ItemShop;
+
+import com.icando.ItemShop.dto.ItemRequest;
+import com.icando.ItemShop.entity.Item;
+
+import com.icando.ItemShop.exception.PointShopException;
+import com.icando.ItemShop.repository.ItemRepository;
+import com.icando.ItemShop.repository.PointShopHistoryRepository;
+import com.icando.ItemShop.service.AdminPointShopService;
+import com.icando.ItemShop.service.UserPointShopService;
+import com.icando.global.upload.S3Uploader;
+import com.icando.member.entity.Member;
+import com.icando.member.entity.Role;
+import com.icando.member.repository.MemberRepository;
+import com.icando.member.repository.PointHistoryRepository;
+import com.icando.member.service.PointService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+public class UserPointShopTest {
+
+
+    @Autowired
+    private AdminPointShopService adminPointShopService;
+
+    @Autowired
+    private UserPointShopService userPointShopService;
+
+    @Autowired
+    private ItemRepository itemRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PointService pointService;
+
+    @Autowired
+    private PointHistoryRepository pointHistoryRepository;
+
+    @MockitoBean
+    private ClientRegistrationRepository clientRegistrationRepository;
+
+    @MockitoBean
+    private S3Uploader s3Uploader;
+
+    private MockMultipartFile imageFile;
+    private Item item;
+    private Long itemId;
+    private Member admin;
+    @Autowired
+    private PointShopHistoryRepository pointShopHistoryRepository;
+
+    @BeforeEach
+    void setup() {
+        String image = "test.jpg";
+        imageFile = new MockMultipartFile("file", image,"image/jpeg", "dummy image data".getBytes());
+        when(s3Uploader.upload(any(MockMultipartFile.class), anyString()))
+                .thenReturn("https://test-url.com/test.jpg");
+        ItemRequest itemDetail = new ItemRequest("치킨",imageFile,2,10);
+        admin = Member.createLocalMemberByTest(
+                1L,
+                "admin",
+                "admin@example.com",
+                "1234",
+                Role.ADMIN
+        );
+        memberRepository.saveAll(List.of(admin));
+        item = adminPointShopService.createItemByAdminId(itemDetail,"admin@example.com");
+        itemId = item.getId();
+    }
+
+    @Test
+    @DisplayName("동시성 환경 100명 동시 상품 잔량 차감 테스트")
+    public void buy_1000_together() throws InterruptedException {
+        //given
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        List<Member> users = new ArrayList<>();
+        for (int i=0; i <threadCount; i++) {
+            users.add(Member.createLocalMemberByTestByPoint(
+                    "user"+ i,
+                    "user"+ i +"@example.com",
+                    "1234",
+                    Role.USER,
+                    100
+            ));
+        }
+        memberRepository.saveAll(users);
+
+        //when
+        for (int i =0; i < threadCount; i++){
+            final int userIndex = i;
+            String userEmail = users.get(userIndex).getEmail();
+            executorService.execute(()-> {
+                try {
+                    userPointShopService.buyItem(itemId,"01012345678",userEmail);
+                    successCount.incrementAndGet();
+                } catch(PointShopException e) {
+                    failCount.getAndIncrement();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        Item updatedItem = itemRepository.findById(itemId)
+                .orElseThrow(() -> new RuntimeException("Item not found"));
+        System.out.println("구매 상품 수량:" + successCount.get());
+        System.out.println("잔여 상품 수량:" + updatedItem.getQuantity());
+
+        //then
+        System.out.println("실패 횟수:" + failCount.get());
+        System.out.println("성공 횟수:" + successCount.get());
+        assertThat(updatedItem.getQuantity()).isZero();
+        assertThat(failCount.get()).isEqualTo(0);
+        assertThat(successCount.get()).isEqualTo(100);
+
+
+    }
+}
+

--- a/src/test/java/com/icando/ItemShop/UserPointShopTest.java
+++ b/src/test/java/com/icando/ItemShop/UserPointShopTest.java
@@ -141,7 +141,7 @@ public class UserPointShopTest {
         System.out.println("실패 횟수:" + failCount.get());
         System.out.println("성공 횟수:" + successCount.get());
         assertThat(updatedItem.getQuantity()).isZero();
-        assertThat(failCount.get()).isEqualTo(90    0);
+        assertThat(failCount.get()).isEqualTo(900);
         assertThat(successCount.get()).isEqualTo(100);
 
 

--- a/src/test/java/com/icando/ItemShop/UserPointShopTest.java
+++ b/src/test/java/com/icando/ItemShop/UserPointShopTest.java
@@ -79,7 +79,7 @@ public class UserPointShopTest {
         imageFile = new MockMultipartFile("file", image,"image/jpeg", "dummy image data".getBytes());
         when(s3Uploader.upload(any(MockMultipartFile.class), anyString()))
                 .thenReturn("https://test-url.com/test.jpg");
-        ItemRequest itemDetail = new ItemRequest("치킨",imageFile,2,10);
+        ItemRequest itemDetail = new ItemRequest("치킨",imageFile,100,10);
         admin = Member.createLocalMemberByTest(
                 1L,
                 "admin",
@@ -93,10 +93,10 @@ public class UserPointShopTest {
     }
 
     @Test
-    @DisplayName("동시성 환경 100명 동시 상품 잔량 차감 테스트")
+    @DisplayName("동시성 환경 10000명 동시 상품 구매 재고 차감 테스트")
     public void buy_1000_together() throws InterruptedException {
         //given
-        int threadCount = 100;
+        int threadCount = 10000;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
 
@@ -141,7 +141,7 @@ public class UserPointShopTest {
         System.out.println("실패 횟수:" + failCount.get());
         System.out.println("성공 횟수:" + successCount.get());
         assertThat(updatedItem.getQuantity()).isZero();
-        assertThat(failCount.get()).isEqualTo(0);
+        assertThat(failCount.get()).isEqualTo(9900);
         assertThat(successCount.get()).isEqualTo(100);
 
 

--- a/src/test/java/com/icando/ItemShop/UserPointShopTest.java
+++ b/src/test/java/com/icando/ItemShop/UserPointShopTest.java
@@ -141,7 +141,7 @@ public class UserPointShopTest {
         System.out.println("실패 횟수:" + failCount.get());
         System.out.println("성공 횟수:" + successCount.get());
         assertThat(updatedItem.getQuantity()).isZero();
-        assertThat(failCount.get()).isEqualTo(900);
+        assertThat(failCount.get()).isEqualTo(90    0);
         assertThat(successCount.get()).isEqualTo(100);
 
 


### PR DESCRIPTION
## 📌 개요
- 하나의 상품에 대해서 동시에 구매했을 때 발생하는 동시성 문제에 대해서 비관적 락을 사용했습니다

## 🛠️ 작업 내용
- 비관적 락 (`PESSIMISTIC_WRITE`)`findByIdWithLock` 메서드 추가
- 테스트 코드 추가

<img width="678" height="370" alt="image" src="https://github.com/user-attachments/assets/03d87a5f-ddd1-4cef-ad0f-a6e469815197" />

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등
- 서비스 초기 단계로 동시 접속이 많지 않을 것을 예상하여, 추후 아이템 특가 이벤트 진행 위한 확장성을 위해 정합성이 보장되 비관적 락을 사용했습니다

## 📌 추후 계획
- 향후 사용자 증가로 트래픽이 늘어나 특가 이벤트를 진행할 경우, 현재의 비관적 락은 심각한 병목 현상을 유발할 수 있음을 인지하고 있습니다.
- 해당 기능(이벤트) 구현 시점에는, 반드시 Redis 분산 락 또는 대기열(Queue) 시스템을 도입하여 이 로직을 교체할 예정입니다.

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.
close #151 